### PR TITLE
v0.1.6: Fixing Docker to run in Mac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geist_bootloader"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "bootloader & cli for controlling Geist"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,8 @@ pub async fn start(version: Option<String>) -> Result<(), Box<dyn Error>> {
     let run_command = format!(
         "docker run -it --rm \
         --name {} \
-        --net=host \
-        -d \
         --env=\"DISPLAY\" \
+        -d \
         --volume=\"/tmp/.X11-unix:/tmp/.X11-unix:rw\" \
         -v /dev/bus/usb:/dev/bus/usb --device-cgroup-rule='c 189:* rmw' \
         -p 9090:9090 \
@@ -79,6 +78,9 @@ pub async fn start(version: Option<String>) -> Result<(), Box<dyn Error>> {
         CONTAINER_NAME,
         image_name,
     );
+
+    println!("Starting Geist with the following command:");
+    println!("{}", run_command);
 
     // Starting the Docker container
     let start_status = Command::new("bash").arg("-c").arg(run_command).status()?;


### PR DESCRIPTION
## Description
- Removing `--net=host` so that we can get a IP address to connect to the localhost within docker in mac with 
- If you run `docker inspect geist --format '{{.NetworkSettings.IPAddress}}` now, it will show an IP address to connect with
- Solves: https://github.com/faust-computer/geist_bootloader/issues/6
- bump version to `v0.1.6`
- update release script