### PR TITLE
Adding `.env` flag to `start`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/faust-computer/geist_bootloader"
 [dependencies]
 anyhow = "1.0.75"
 # lets add derive feature to clap
-clap = { version = "4.4.7", features = ["derive"] }
-tokio = { version = "1.33.0", features = ["rt-multi-thread", "macros"] }
+clap = { version = "4.4.2", features = ["derive"] }
+tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros"] }
 
 [[bin]]
 name = "geist"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geist_bootloader"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "bootloader & cli for controlling Geist"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
+use std::path::Path;
 use std::process::Command;
 use std::process::Output;
-use std::path::Path;
 
 const BUILD_PATH: &str = "geist_ws/src/geist";
 const IMAGE_NAME: &str = "geist";
@@ -55,7 +55,10 @@ pub async fn logs() -> Result<(), Box<dyn Error>> {
 }
 
 /// This is the function that starts the Geist container
-pub async fn start(version: Option<String>, env_file: Option<String>) -> Result<(), Box<dyn Error>> {
+pub async fn start(
+    version: Option<String>,
+    env_file: Option<String>,
+) -> Result<(), Box<dyn Error>> {
     // Existing version string logic
     let ver = version.unwrap_or_else(|| "latest".to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,11 +89,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ServiceOpts::List => geist_bootloader::list_services().await?,
         },
         Commands::Start(start_opts) => {
-            geist_bootloader::start(
-                start_opts.version.clone(), 
-                start_opts.env_file.clone()
-        ).await?
-        },
+            geist_bootloader::start(start_opts.version.clone(), start_opts.env_file.clone()).await?
+        }
         Commands::Stop => geist_bootloader::stop().await?,
         Commands::Topic(topic_command) => match &topic_command.opt {
             TopicOpts::List => geist_bootloader::list_topics().await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ enum Commands {
 struct StartOpts {
     #[clap(short, long)]
     version: Option<String>,
+    /// Optional path to the .env file
+    #[clap(short, long)]
+    env_file: Option<String>,
 }
 
 #[derive(Args)]
@@ -85,7 +88,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Service(service_command) => match &service_command.opt {
             ServiceOpts::List => geist_bootloader::list_services().await?,
         },
-        Commands::Start(start_opts) => geist_bootloader::start(start_opts.version.clone()).await?,
+        Commands::Start(start_opts) => {
+            geist_bootloader::start(
+                start_opts.version.clone(), 
+                start_opts.env_file.clone()
+        ).await?
+        },
         Commands::Stop => geist_bootloader::stop().await?,
         Commands::Topic(topic_command) => match &topic_command.opt {
             TopicOpts::List => geist_bootloader::list_topics().await?,


### PR DESCRIPTION
## Description

Adding a `--env` and `-e` flag to `start so that `aes_sedai` can be started with a .env

- This is undoubtedly not a long term solution, but will do for now in passing private keys etc to Geist that is going to run
- Some better documentation of functions
- Also going to kick start `v0.1.7` of `geist_bootloader`